### PR TITLE
Use Cache directory & A fix to add location of R to PATH

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -45,7 +45,8 @@ cp -R $VENDOR_DIR/* /app/vendor
 
 
 # R needs to know where gfortran and glibc header files are
-export PATH=/app/vendor/gcc-4.3/bin:$PATH
+# For buildpacks that get run after, need to update PATH with location of R
+export PATH=/app/vendor/R/bin/:/app/vendor/gcc-4.3/bin:$PATH
 export LDFLAGS="-L/app/vendor/gcc-4.3/lib64/"
 export CPPFLAGS="-I/app/vendor/glibc-2.7/string/ -I/app/vendor/glibc-2.7/time"
 export R_INCLUDE=/app/vendor/R/lib64/R/include


### PR DESCRIPTION
I highly suggest adding my most recent commit today to update the PATH in bin/compile to include the location of R.  Without this other buildpacks cannot install anything which might depend on R -- specifically I was attempting to install rpy2 with the python buildpack (which failed because it couldn't find R).

The caching stuff (most of the changes) has been working for me, perhaps you'll like this as well.
