### PR TITLE
Bug fix on the cp -R command that copy in an inconsistent way

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -89,6 +89,6 @@ RPROG
 echo "R $R_VERSION successfully installed" | indent
 
 # need to copy binaries back so that any installed packages are included in the slug
-cp -R /app/vendor/R $VENDOR_DIR/R
+cp -R /app/vendor/R/* $VENDOR_DIR/R/
 
 # TODO: remove unneeded files to make slug smaller


### PR DESCRIPTION
The last instruction of compile is "cp -R", and it was copying /app/vendor/R into $VENDOR_DIR/R. It's not a correct behaviour, because the R folder become a subfolder of $VENDOR_DIR/R, so the newly installed packages can't be found.

BTW thank you @virtualstaticvoid for your amazing work on this buildpack!
