### PR TITLE
change R_HOME to point to /app/vendor/R/lib64/R

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -42,7 +42,7 @@ S3_BUCKET="heroku-buildpack-r"
 R_BINARIES="http://${S3_BUCKET}.s3.amazonaws.com/R-${R_VERSION}-binaries-${BUILD_PACK_VERSION}.tar.gz"
 
 VENDOR_DIR="$BUILD_DIR/vendor"
-R_HOME="$VENDOR_DIR/R"
+R_BASE="$VENDOR_DIR/R"
 CRAN_MIRROR="http://cran.revolutionanalytics.com"
 
 mkdir -p $CACHE_DIR
@@ -64,8 +64,8 @@ cp -R $VENDOR_DIR/R /app/vendor/R
 export PATH=/app/vendor/R/bin:/app/vendor/gcc-$GCC_VERSION/bin:$PATH
 export LDFLAGS="-L/app/vendor/gcc-$GCC_VERSION/lib64/"
 export CPPFLAGS="-I/app/vendor/glibc-$GLIBC_VERSION/string/ -I/app/vendor/glibc-$GLIBC_VERSION/time"
-export R_HOME=/app/vendor/R
-export R_INCLUDE=$R_HOME/lib64/R/include
+export R_HOME=$R_BASE/lib64/R
+export R_INCLUDE=$R_HOME/include
 
 # copy over environment
 mkdir -p $BUILD_DIR/.profile.d

--- a/bin/r_environment.sh
+++ b/bin/r_environment.sh
@@ -2,6 +2,7 @@
 
 GCC_VERSION="4.3"
 
-export R_HOME=/app/vendor/R
-export R_INCLUDE=$R_HOME/lib64/R/include
-export PATH=$R_HOME/bin:/app/vendor/gcc-$GCC_VERSION/bin:$PATH
+export R_BASE=/app/vendor/R
+export R_HOME=$R_BASE/lib64/R
+export R_INCLUDE=$R_HOME/include
+export PATH=$R_BASE/bin:/app/vendor/gcc-$GCC_VERSION/bin:$PATH


### PR DESCRIPTION
Hi Chris,

I've been using your heroku-buildpack-r today, to try to get R running with python. I'm using the rpy2 library (http://rpy.sourceforge.net/rpy2.html) to call R code from python.

One problem that I've been having is the rpy2 looks at the R_HOME environment variable set in your code, but it is pointing at the wrong directory.  I believe the R_HOME directory should be /app/vendor/R/lib64/R rather than /app/vendor/R.  The rpy2 code looks for $R_HOME/etc/Renviron for example.

If you run your current code, you'll notice a warning that R is ignoring the value of R_HOME.  You can also see from the R.home() function that R believes the directory is /app/vendor/R/lib64/R.  So R is fine, but downstream code will be using the wrong directory.

I have changed the directories, creating a new variable R_BASE for /app/vendor/R, and computing the R_HOME off of that.

This is the first pull request I've ever done, so my apologies if I screw something up.

With the current code you get:

``` bash
(django160)[cschmidt@egon:~/pa/test-just-r]$ heroku run R
```

``` R
Running `R` attached to terminal... up, run.1562
WARNING: ignoring environment value of R_HOME

R version 2.15.1 (2012-06-22) -- "Roasted Marshmallows"
Copyright (C) 2012 The R Foundation for Statistical Computing
ISBN 3-900051-07-0
Platform: x86_64-unknown-linux-gnu (64-bit)

R is free software and comes with ABSOLUTELY NO WARRANTY.
You are welcome to redistribute it under certain conditions.
Type 'license()' or 'licence()' for distribution details.

R is a collaborative project with many contributors.
Type 'contributors()' for more information and
'citation()' on how to cite R or R packages in publications.

Type 'demo()' for some demos, 'help()' for on-line help, or
'help.start()' for an HTML browser interface to help.
Type 'q()' to quit R.

> R.home()
[1] "/app/vendor/R/lib64/R"
```

``` bash
(django160)[cschmidt@egon:~/pa/test-just-r]$ heroku run bash
Running `bash` attached to terminal... up, run.1385
~ $ echo $R_HOME
/app/vendor/R
~ $ cd /app/vendor/R/lib64/R                                                    
~/vendor/R/lib64/R $ ls
bin  doc  etc  include  lib  library  modules  share
```

Thanks,
Craig Schmidt
