### PR TITLE
Avoid to call unexisting variables (LD_LIBRARY_PATH, ...)

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -77,13 +77,13 @@ cp -R $VENDOR_DIR/R/* /app/vendor/R
 # needed for compiling packages
 export PATH="/app/vendor/R/bin:/app/.apt/usr/bin:/app/bin:/usr/ruby1.9.2/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/bin:/usr/sbin:/sbin:$PATH"
 export R_INCLUDE="/app/vendor/R/lib64/R/include"
-export LD_LIBRARY_PATH="/app/.apt/usr/lib/libblas:/app/.apt/usr/lib/lapack:/app/.apt/usr/lib/x86_64-linux-gnu:/app/.apt/usr/lib/i386-linux-gnu:/app/.apt/usr/lib:$LD_LIBRARY_PATH"
-export LIBRARY_PATH="/app/.apt/usr/lib/x86_64-linux-gnu:/app/.apt/usr/lib/i386-linux-gnu:/app/.apt/usr/lib:$LIBRARY_PATH"
-export INCLUDE_PATH="/app/.apt/usr/include:$INCLUDE_PATH"
+export LD_LIBRARY_PATH="/app/.apt/usr/lib/libblas:/app/.apt/usr/lib/lapack:/app/.apt/usr/lib/x86_64-linux-gnu:/app/.apt/usr/lib/i386-linux-gnu:/app/.apt/usr/lib:${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+export LIBRARY_PATH="/app/.apt/usr/lib/x86_64-linux-gnu:/app/.apt/usr/lib/i386-linux-gnu:/app/.apt/usr/lib:${LIBRARY_PATH:+:$LIBRARY_PATH}"
+export INCLUDE_PATH="/app/.apt/usr/include:${INCLUDE_PATH:+:$INCLUDE_PATH}"
 export CPATH="$INCLUDE_PATH"
 export CPPPATH="$INCLUDE_PATH"
-export PKG_CONFIG_PATH="/app/.apt/usr/lib/x86_64-linux-gnu/pkgconfig:/app/.apt/usr/lib/i386-linux-gnu/pkgconfig:/app/.apt/usr/lib/pkgconfig:$PKG_CONFIG_PATH"
-export LDFLAGS="-L/app/.apt/usr/lib/libblas -L/app/.apt/usr/lib/lapack $LDFLAGS"
+export PKG_CONFIG_PATH="/app/.apt/usr/lib/x86_64-linux-gnu/pkgconfig:/app/.apt/usr/lib/i386-linux-gnu/pkgconfig:/app/.apt/usr/lib/pkgconfig:${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}"
+export LDFLAGS="-L/app/.apt/usr/lib/libblas -L/app/.apt/usr/lib/lapack ${LDFLAGS:+:$LDFLAGS}"
 
 # copy over environment
 mkdir -p $BUILD_DIR/.profile.d


### PR DESCRIPTION
When we concatenate the variables PATH, R_INCLUDE, LD_LIBRARY_PATH, ... , some of them are not existing yet. Just test their existence with that *trick*: ${INCLUDE_PATH:+:$INCLUDE_PATH}".
Picked from [there](http://stackoverflow.com/questions/9631228/how-to-smart-append-ld-library-path-in-shell-when-nounset)