### PR TITLE
Fix for using R buildpack together with Apt buildpack

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -72,7 +72,13 @@ echo "Vendoring R $R_VERSION for $STACK stack ($BUILD_PACK_VERSION)" | indent
 # download and unpack binaries
 echo "Downloading and unpacking R binaries ($R_BINARIES)" | indent
 curl $R_BINARIES -s -o - | tar xzf - -C $BUILD_DIR
-mv $VENDOR_DIR/.apt/ $BUILD_DIR
+
+# also using buildpack-apt?
+if [ -d $BUILD_DIR/.apt ]; then
+  cp -r $VENDOR_DIR/.apt/ $BUILD_DIR
+else
+  mv $VENDOR_DIR/.apt/ $BUILD_DIR
+fi
 
 # need to copy the binaries to /app/vendor so that R works when compiling packages
 

--- a/test/rgeos/.buildpacks
+++ b/test/rgeos/.buildpacks
@@ -1,0 +1,2 @@
+https://github.com/ddollar/heroku-buildpack-apt
+https://github.com/virtualstaticvoid/heroku-buildpack-r.git#cedar-14-apt

--- a/test/rgeos/.buildpacks
+++ b/test/rgeos/.buildpacks
@@ -1,2 +1,0 @@
-https://github.com/ddollar/heroku-buildpack-apt
-https://github.com/virtualstaticvoid/heroku-buildpack-r.git#cedar-14-apt

--- a/test/rgeos/Aptfile
+++ b/test/rgeos/Aptfile
@@ -1,0 +1,1 @@
+libgeos-dev

--- a/test/rgeos/init.r
+++ b/test/rgeos/init.r
@@ -1,0 +1,21 @@
+#
+# Example R code to install packages
+# See http://cran.r-project.org/doc/manuals/R-admin.html#Installing-packages for details
+#
+
+###########################################################
+# Update this line with the R packages to install:
+
+my_packages = c("rgeos")
+
+###########################################################
+
+install_if_missing = function(p) {
+  if (p %in% rownames(installed.packages()) == FALSE) {
+    install.packages(p, dependencies = TRUE)
+  }
+  else {
+    cat(paste("Skipping already installed package:", p, "\n"))
+  }
+}
+invisible(sapply(my_packages, install_if_missing))

--- a/test/rgeos/install
+++ b/test/rgeos/install
@@ -11,10 +11,13 @@ git init
 git add --all
 git commit -m "initial"
 
-heroku create --stack cedar-14 --buildpack https://github.com/ddollar/heroku-buildpack-multi.git
+heroku create --stack cedar-14
 
 app=`heroku apps:info -s | grep ^git-url=`
 app=${app:31:-4}  # git-url=https://git.heroku.com/app-name-number.git
+
+heroku buildpacks:add https://github.com/heroku/heroku-buildpack-apt.git --app $app
+heroku buildpacks:add https://github.com/virtualstaticvoid/heroku-buildpack-r#cedar-14-apt --app $app
 
 git push heroku master
 

--- a/test/rgeos/install
+++ b/test/rgeos/install
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+shopt -s extglob
+set -e
+
+dir=`mktemp -d`
+cp -r . $dir
+pushd $dir
+
+git init
+git add --all
+git commit -m "initial"
+
+heroku create --stack cedar-14 --buildpack https://github.com/ddollar/heroku-buildpack-multi.git
+
+app=`heroku apps:info -s | grep ^git-url=`
+app=${app:31:-4}  # git-url=https://git.heroku.com/app-name-number.git
+
+git push heroku master
+
+# run R console
+heroku run 'R --no-save -f prog.r' --app $app
+
+popd
+
+# clean up
+heroku apps:destroy $app --confirm $app
+rm -rf $dir

--- a/test/rgeos/prog.r
+++ b/test/rgeos/prog.r
@@ -1,0 +1,20 @@
+#
+# Example R program
+#
+
+library(rgeos)
+
+# Example taken from rgeos documentation
+
+gArea(readWKT("POINT(1 1)"))
+gArea(readWKT("LINESTRING(0 0,1 1,2 2)"))
+gArea(readWKT("LINEARRING(0 0,3 0,3 3,0 3,0 0)"))
+
+p1 = readWKT("POLYGON((0 0,3 0,3 3,0 3,0 0))")
+p2 = readWKT("POLYGON((0 0,3 0,3 3,0 3,0 0),(1 1,2 1,2 2,1 2,1 1))")
+
+gArea(p1)
+p1@polygons[[1]]@area
+
+gArea(p2)
+p2@polygons[[1]]@area


### PR DESCRIPTION
Fixes error when using [heroku-buildpack-apt](https://github.com/heroku/heroku-buildpack-apt) together with this one.

```
-----> Fetching set buildpack https://github.com/heroku/heroku-buildpack-multi... done
-----> Multipack app detected
=====> Downloading Buildpack: https://github.com/heroku/heroku-buildpack-apt
=====> Detected Framework: Apt
-----> Updating apt caches
       Ign http://archive.ubuntu.com trusty InRelease
       Get:1 http://archive.ubuntu.com trusty-security InRelease [65.9 kB]
       Get:2 http://apt.postgresql.org trusty-pgdg InRelease [33.8 kB]
       Get:3 http://archive.ubuntu.com trusty-updates InRelease [65.9 kB]
       Get:4 http://archive.ubuntu.com trusty Release.gpg [933 B]
       Get:5 http://archive.ubuntu.com trusty Release [58.5 kB]
       Get:6 http://archive.ubuntu.com trusty-security/main amd64 Packages [466 kB]
       Get:7 http://archive.ubuntu.com trusty-security/main Translation-en [257 kB]
       Get:8 http://archive.ubuntu.com trusty-updates/main amd64 Packages [768 kB]
       Get:9 http://archive.ubuntu.com trusty-updates/main Translation-en [384 kB]
       Get:10 http://archive.ubuntu.com trusty/main amd64 Packages [1,350 kB]
       Get:11 http://apt.postgresql.org trusty-pgdg/main amd64 Packages [58.8 kB]
       Get:12 http://archive.ubuntu.com trusty/universe amd64 Packages [5,859 kB]
       Get:13 http://archive.ubuntu.com trusty/main Translation-en [762 kB]
       Get:14 http://archive.ubuntu.com trusty/universe Translation-en [4,089 kB]
       Ign http://archive.ubuntu.com trusty/main Translation-en_US
       Ign http://apt.postgresql.org trusty-pgdg/main Translation-en_US
       Ign http://archive.ubuntu.com trusty/universe Translation-en_US
       Ign http://apt.postgresql.org trusty-pgdg/main Translation-en
       Fetched 14.2 MB in 7s (1,810 kB/s)
       Reading package lists...
-----> Fetching .debs for libgeos-dev
       Reading package lists...
       Building dependency tree...
       The following extra packages will be installed:
         libgeos-3.4.2 libgeos-c1
       Suggested packages:
         libgdal-doc
       The following NEW packages will be installed:
         libgeos-3.4.2 libgeos-c1 libgeos-dev
       0 upgraded, 3 newly installed, 0 to remove and 14 not upgraded.
       Need to get 512 kB of archives.
       After this operation, 2,227 kB of additional disk space will be used.
       Get:1 http://archive.ubuntu.com/ubuntu/ trusty/universe libgeos-3.4.2 amd64 3.4.2-4ubuntu1 [411 kB]
       Get:2 http://archive.ubuntu.com/ubuntu/ trusty/universe libgeos-c1 amd64 3.4.2-4ubuntu1 [42.6 kB]
       Get:3 http://archive.ubuntu.com/ubuntu/ trusty/universe libgeos-dev amd64 3.4.2-4ubuntu1 [58.4 kB]
       Fetched 512 kB in 0s (841 kB/s)
       Download complete and in download only mode
-----> Installing libgeos-3.4.2_3.4.2-4ubuntu1_amd64.deb
-----> Installing libgeos-c1_3.4.2-4ubuntu1_amd64.deb
-----> Installing libgeos-dev_3.4.2-4ubuntu1_amd64.deb
-----> Writing profile script
=====> Downloading Buildpack: http://github.com/virtualstaticvoid/heroku-buildpack-r.git
=====> Detected Framework: R
       Vendoring R 3.2.4 for cedar-14 stack (20160322-0811)
       Downloading and unpacking R binaries (http://heroku-buildpack-r.s3.amazonaws.com/cedar-14/R-3.2.4-binaries-20160322-0811.tar.gz)
mv: cannot move ‘/tmp/build_c048b4cdb866f298a5b4bfa252e323a8/arquenum13-Test-6f96514/vendor/.apt/’ to ‘/tmp/build_c048b4cdb866f298a5b4bfa252e323a8/arquenum13-Test-6f96514/.apt’: Directory not empty
 !     Push rejected, failed to compile Multipack app
```