### PR TITLE
Populate only R files from build cache to build.

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -73,7 +73,8 @@ echo "Vendoring R $R_VERSION for $STACK stack ($BUILD_PACK_VERSION)" | indent
 if [ "$(cat $CACHE_DIR/vendor/R/bin/.version 2>/dev/null)" = "$R_VERSION" ]
 then
   echo "Desired R version ($R_VERSION) cached" | indent
-  cp -R $CACHE_DIR/* $BUILD_DIR
+  cp -R $CACHE_DIR/vendor/R $VENDOR_DIR/.
+  cp -R $CACHE_DIR/vendor/.apt $VENDOR_DIR/.
 else
   # download and unpack binaries
   echo "Downloading and unpacking R binaries ($R_BINARIES)" | indent


### PR DESCRIPTION
This is a proposed fix/workaround for issue https://github.com/virtualstaticvoid/heroku-buildpack-r/issues/66